### PR TITLE
Update SeoVisualizerController.controller.js

### DIFF
--- a/SeoVisualizer/App_Plugins/SeoVisualizer/SeoVisualizerController.controller.js
+++ b/SeoVisualizer/App_Plugins/SeoVisualizer/SeoVisualizerController.controller.js
@@ -64,8 +64,11 @@ angular.module("umbraco")
                 return title;
             }
 
-            if ($scope.model && $scope.model.config && $scope.model.config.titleSuffix !== '') {
+            // Only append suffix if there is a value set
+            if ($scope.model && $scope.model.config && $scope.model.config.titleSuffix && $scope.model.config.titleSuffix !== '') {
                 return title + ' ' + $scope.model.config.titleSuffix;
+            } else {
+                return title;
             }
 
         };


### PR DESCRIPTION
Fixes 'undefined' being added to the title preview if no suffix is set.

If you do not enter a value in 'Default Title Suffix' in the data type, then it shows the value 'undefined' as the suffix in the preview.